### PR TITLE
Pin gitleaks to v1.6.0

### DIFF
--- a/.github/workflows/secretScan.yml
+++ b/.github/workflows/secretScan.yml
@@ -6,8 +6,7 @@ jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
-      - uses: gitleaks/gitleaks-action@v1.6.0
+      - uses: actions/checkout@v3
         with:
-          fetch-depth: '0'
-      - name: gitleaks-action
-        uses: zricethezav/gitleaks-action@master
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v1.6.0


### PR DESCRIPTION
@nathanvaughan-NOAA I noticed you were trying to pin gitleaks-action to v1.6.0. It looks like you also left a gitleaks-action@master which is causing your pipelines to still fail since `@master` requires a license-key. Let me know if you need help acquiring one!

Cheers